### PR TITLE
Make component optionally a list

### DIFF
--- a/x-translator/smartapi_x-translator_schema.json
+++ b/x-translator/smartapi_x-translator_schema.json
@@ -15,12 +15,27 @@
           ],
           "properties": {
             "component": {
-              "type": "string",
-              "enum": [
-                "KP",
-                "ARA",
-                "ARS",
-                "Utility"
+              "oneOf": [
+                {"type": "string",
+                "enum": [
+                  "KP",
+                  "ARA",
+                  "ARS",
+                  "Utility"
+                ]},
+                {
+                  "type": "array",
+                  "minItems": 1,
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "KP",
+                      "ARA",
+                      "ARS",
+                      "Utility"
+                    ]}
+                }
               ]
             },
             "team": {


### PR DESCRIPTION
Many teams use BTE (identified as an ARA) as a KP since it provides a trapi interface to non-trapi services.    This requires special casing in the calling ARAs, so it would be nice if BTE were able to identify as both a KP and an ARA in the registry.   This change would allow that.

For simplicity, but at the cost of losing backwards compatibility, the oneOf could be removed in place of just converting the string value of component to an array value.