### PR TITLE
added test_data_location extension to x_trapi

### DIFF
--- a/x-trapi/smartapi_x-trapi_schema.json
+++ b/x-trapi/smartapi_x-trapi_schema.json
@@ -36,6 +36,11 @@
               "type": "integer",
               "minimum": -1,
               "default": -1
+            },
+            "test_data_location": {
+              "description": "URL that resolves to test data in the API's source code repository.",
+              "type": "string",
+              "format": "uri"
             }
           }
         }


### PR DESCRIPTION
This adds "test_data_location" to the x-trapi extension.
The test data location is a URL to a file in a TRAPI KPs' repository that holds example triples for each triple type in the resource.