### PR TITLE
Add x-bte schema extension 

### DIFF
--- a/x-bte/README.md
+++ b/x-bte/README.md
@@ -1,0 +1,3 @@
+# x-bte extension
+
+This is the folder to put the schema for the `x-bte` metadata extension for the Registry as well as any associated files.

--- a/x-bte/smartapi_x-bte_examples.md
+++ b/x-bte/smartapi_x-bte_examples.md
@@ -1,0 +1,71 @@
+## Examples that should pass validation
+
+This should work:
+
+```yaml
+tags:
+  - name: translator
+  - name: biothings
+info:
+  x-translator:
+    component: KP
+    team:
+      - Service Provider
+    biolink-version: 2.2.16
+    infores: "infores:biolink-api"
+```
+
+## Examples with ERRORS that should fail validation
+
+Error: the `team` value cannot be a string (it must be an array, even if it’s a one-element array).
+
+```yaml
+tags:
+  - name: translator
+  - name: biothings
+info:
+  x-translator:
+    component: KP
+    team: Service Provider
+```
+
+Within `info.x-translator`, `component` and `team` both need to be present. Below, the property `component` is misspelled.
+
+```yaml
+tags:
+  - name: translator
+  - name: biothings
+info:
+  x-translator:
+    compnent: KP
+    team:
+      - Service Provider
+```
+
+The `team` field cannot be an empty array.
+
+```yaml
+tags:
+  - name: translator
+  - name: biothings
+info:
+  x-translator:
+    component: KP
+    team: []
+```
+
+The `infores` field's value must be a full CURIE with namespace prefix `infores:`. Below, the field's value is missing the prefix.
+
+```yaml
+tags:
+  - name: translator
+  - name: biothings
+info:
+  x-translator:
+    component: KP
+    team:
+      - Service Provider
+    biolink-version: 2.2.16
+    infores: biolink-api
+```
+---

--- a/x-bte/smartapi_x-bte_examples.md
+++ b/x-bte/smartapi_x-bte_examples.md
@@ -1,71 +1,116 @@
-## Examples that should pass validation
+### Examples that should pass validation
 
-This should work:
+#### Example 1: Valid `x-bte` Extension
+This example correctly defines both `x-bte-kgs-operations` and `x-bte-response-mapping` properties, adhering to the schema requirements:
 
 ```yaml
-tags:
-  - name: translator
-  - name: biothings
-info:
-  x-translator:
-    component: KP
-    team:
-      - Service Provider
-    biolink-version: 2.2.16
-    infores: "infores:biolink-api"
+components:
+  x-bte-kgs-operations:
+    myOperation:
+      - supportBatch: true
+        useTemplating: true
+        inputs:
+          - id: CHEBI
+            semantic: SmallMolecule
+        requestBody:
+          body: "example request body"
+        outputs:
+          - id: RHEA
+            semantic: MolecularActivity
+        parameters:
+          fields: "exampleField"
+          size: 1000
+        predicate: "participates_in"
+        source: "infores:rhea"
+        response_mapping:
+          source_url: "http://example.com/response"
+  x-bte-response-mapping:
+    exampleMapping:
+      source_url: "http://example.com"
+      edge-attributes: "example attributes"
+      ref_input: "example input"
+      ref_output: "example output"
 ```
 
-## Examples with ERRORS that should fail validation
+### Examples with ERRORS that should fail validation
 
-Error: the `team` value cannot be a string (it must be an array, even if it’s a one-element array).
+#### Example 1: Missing `supportBatch` Property
+The `supportBatch` property is required when defining operations within `x-bte-kgs-operations`. This example will fail validation because `supportBatch` is missing:
 
 ```yaml
-tags:
-  - name: translator
-  - name: biothings
+components:
+  x-bte-kgs-operations:
+    myOperation:
+      - useTemplating: true
+        inputs:
+          - id: CHEBI
+            semantic: SmallMolecule
+        requestBody:
+          body: "example request body"
+        outputs:
+          - id: RHEA
+            semantic: MolecularActivity
+        parameters:
+          fields: "exampleField"
+          size: 1000
+        predicate: "participates_in"
+        source: "infores:rhea"
+        response_mapping:
+          source_url: "http://example.com/response"
+```
+
+#### Example 2: `team` Field is Not an Array
+The `team` field should be an array, even if it contains only one element. This example will fail because `team` is provided as a string:
+
+```yaml
+components:
+  x-bte-kgs-operations:
+    myOperation:
+      - supportBatch: true
+        useTemplating: true
+        inputs:
+          - id: CHEBI
+            semantic: SmallMolecule
+        requestBody:
+          body: "example request body"
+        outputs:
+          - id: RHEA
+            semantic: MolecularActivity
+        parameters:
+          fields: "exampleField"
+          size: 1000
+        predicate: "participates_in"
+        source: "infores:rhea"
+        response_mapping:
+          source_url: "http://example.com/response"
 info:
   x-translator:
     component: KP
     team: Service Provider
 ```
 
-Within `info.x-translator`, `component` and `team` both need to be present. Below, the property `component` is misspelled.
+#### Example 3: Incorrect CURIE Format in `source`
+The `source` field must follow the `infores:` CURIE format. The following example will fail because the `source` field does not include the required `infores:` prefix:
 
 ```yaml
-tags:
-  - name: translator
-  - name: biothings
-info:
-  x-translator:
-    compnent: KP
-    team:
-      - Service Provider
+components:
+  x-bte-kgs-operations:
+    myOperation:
+      - supportBatch: true
+        useTemplating: true
+        inputs:
+          - id: CHEBI
+            semantic: SmallMolecule
+        requestBody:
+          body: "example request body"
+        outputs:
+          - id: RHEA
+            semantic: MolecularActivity
+        parameters:
+          fields: "exampleField"
+          size: 1000
+        predicate: "participates_in"
+        source: "rhea"  # This should be prefixed with "infores:"
+        response_mapping:
+          source_url: "http://example.com/response"
 ```
-
-The `team` field cannot be an empty array.
-
-```yaml
-tags:
-  - name: translator
-  - name: biothings
-info:
-  x-translator:
-    component: KP
-    team: []
-```
-
-The `infores` field's value must be a full CURIE with namespace prefix `infores:`. Below, the field's value is missing the prefix.
-
-```yaml
-tags:
-  - name: translator
-  - name: biothings
-info:
-  x-translator:
-    component: KP
-    team:
-      - Service Provider
-    biolink-version: 2.2.16
-    infores: biolink-api
-```
----

--- a/x-bte/smartapi_x-bte_schema.json
+++ b/x-bte/smartapi_x-bte_schema.json
@@ -1,0 +1,264 @@
+{
+    "title": "The x-bte extension in SmartAPI",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "description": "Schema for the x-bte extension. Assumes that the components section is used to list the operation contents, which are then referenced in lists hanging off the endpoints that should be used by BTE",
+    "properties": {
+        "components": {
+            "type": "object",
+            "properties": {
+                "x-bte-kgs-operations": {
+                    "type": "object",
+                    "description": "This a collection of operations, the patternProperties is a regex used to match the operation name, which is what the user defines",
+                    "minProperties": 1,
+                    "patternProperties": {
+                        "^[A-Za-z0-9_-]+$": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/operation"
+                            },
+                            "minItems": 1,
+                            "maxItems": 1,
+                            "description": "maxItems is set to 1, currently value is set as 1-element array"
+                        }
+                    }
+                },
+                "x-bte-response-mapping": {
+                    "$ref": "#/$defs/responseMapping"
+                }
+            }
+        }
+    },
+    "allOf": [
+        {
+            "if": {
+                "properties": {
+                    "components": {
+                        "properties": {
+                            "x-bte-kgs-operations": {
+                                "type": "object"
+                            }
+                        },
+                        "required": ["x-bte-kgs-operations"]
+                    }
+                }
+            },
+            "then": {
+                "properties": {
+                    "components": {
+                        "properties": {
+                            "x-bte-kgs-operations": {
+                                "type": "object",
+                                "patternProperties": {
+                                    "^[A-Za-z0-9_-]+$": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "required": ["supportBatch"],
+                                            "properties": {
+                                                "supportBatch": {
+                                                    "type": "boolean"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "x-bte-response-mapping": {
+                                "$ref": "#/$defs/responseMapping"
+                            }
+                        },
+                        "required": ["x-bte-response-mapping"]
+                    }
+                }
+            }
+        },
+        {
+            "if": {
+                "properties": {
+                    "components": {
+                        "properties": {
+                            "x-bte-response-mapping": {
+                                "type": "object"
+                            }
+                        },
+                        "required": ["x-bte-response-mapping"]
+                    }
+                }
+            },
+            "then": {
+                "properties": {
+                    "components": {
+                        "properties": {
+                            "x-bte-kgs-operations": {
+                                "type": "object",
+                                "patternProperties": {
+                                    "^[A-Za-z0-9_-]+$": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "required": ["supportBatch"],
+                                            "properties": {
+                                                "supportBatch": {
+                                                    "type": "boolean"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "required": ["x-bte-kgs-operations"]
+                    }
+                }
+            }
+        }
+    ],
+    "$defs": {
+        "operation": {
+            "type": "object",
+            "properties": {
+                "supportBatch": {
+                    "type": "boolean"
+                },
+                "useTemplating": {
+                    "type": "boolean"
+                },
+                "inputs": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string"
+                            },
+                            "semantic": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["id", "semantic"]
+                    },
+                    "minItems": 1,
+                    "maxItems": 1,
+                    "description": "maxItems is set to 1, current design set as 1-element array"
+                },
+                "requestBody": {
+                    "type": "object",
+                    "properties": {
+                        "body": {
+                            "type": ["object", "string"]
+                        }
+                    },
+                    "required": ["body"]
+                },
+                "requestBodyType": {
+                    "type": "string",
+                    "enum": ["object"]
+                },
+                "outputs": {
+                    "type": "array",
+                    "description": "The outputs of the operation are same as inputs, possible modification in future",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string"
+                            },
+                            "semantic": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["id", "semantic"]
+                    },
+                    "minItems": 1,
+                    "maxItems": 1
+                },
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "fields": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "predicate": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string",
+                    "pattern": "^infores:.+"
+                },
+                "qualifiers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "minProperties": 1
+                },
+                "knowledge_level": {
+                    "type": "string"
+                },
+                "agent_type": {
+                    "type": "string"
+                },
+                "testExamples": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "qInput": {
+                                "type": "string"
+                            },
+                            "oneOutput": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["qInput", "oneOutput"]
+                    }
+                },
+                "response_mapping": {
+                    "$ref": "#/$defs/responseMapping"
+                }
+            },
+            "required": ["supportBatch", "useTemplating", "inputs", "outputs", "predicate", "response_mapping"]
+        },
+        "responseMapping": {
+            "type": "object",
+            "minProperties": 1,
+            "description": "This a collection of response mappings, the patternProperties is a regex used to match the response mapping names.",
+            "patternProperties": {
+                "^[A-Za-z0-9_:-]+$": {
+                    "type": "object",
+                    "description": "This is for the name of other response mapping keys, that are not defined in properties."
+                }
+            },
+            "properties": {
+                "source_url": {
+                    "type": "string"
+                },
+                "edge-attributes": {
+                    "type": "string"
+                },
+                "trapi_sources": {
+                    "type": "string"
+                },
+                "ref_input": {
+                    "type": "string"
+                },
+                "ref_output": {
+                    "type": "string"
+                },
+                "input_name": {
+                    "type": "string"
+                },
+                "output_name": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adding working schema and markdown file examples. 
Reference [ smartapi issue#236 ](https://github.com/SmartAPI/smartAPI/issues/236) for further insight. 